### PR TITLE
Remove code signing

### DIFF
--- a/QuiltDemo.xcodeproj/project.pbxproj
+++ b/QuiltDemo.xcodeproj/project.pbxproj
@@ -107,7 +107,6 @@
 				TargetAttributes = {
 					C99C0F9D1E0FB553005194A7 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 8VYQ2497BU;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -273,7 +272,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 8VYQ2497BU;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = QuiltDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = holight.QuiltDemo;
@@ -286,7 +285,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 8VYQ2497BU;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = QuiltDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = holight.QuiltDemo;


### PR DESCRIPTION
It is common to not include signing information in the .xcodeproj when publishing, so other people can try it out without hassle.